### PR TITLE
Fixed bug with go list not returning a trailing slash anymore

### DIFF
--- a/coverage.el
+++ b/coverage.el
@@ -535,7 +535,7 @@ SOURCE is a dotted pair (TOOL . FILE-NAME).
                 ;; Use 'go list' to avoid handling GOPATH, vendoring etc.
                 (cl-letf ((files (cov--profile-files profile)))
                   (when files
-                    (concat (car (cov--go-list-root files)) "src/"))))))
+                    (concat (file-name-as-directory (car (cov--go-list-root files))) "src/"))))))
 
 (cl-defun cov--go-list-root (files)
   (apply 'process-lines


### PR DESCRIPTION
I believe that `go list -f {{.Root}}` historically returned the directory with a trailing slash.

However for me (go version 1.8.1), it does not seem to be the case, which makes the whole package non-functioning for usage with modern go versions. This change adds the trailing slash if it is not present. 